### PR TITLE
Update grid

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ var paths = {
     src: './src/example/favicon.png',
     dev: './dev/images'
   },
-  watch: './src/*'
+  watch: './src/**/*'
 }
 
 var processors = [

--- a/src/example/test.html
+++ b/src/example/test.html
@@ -12,7 +12,8 @@
 
   <style>
     .demo-col {
-      padding: 1em;
+      padding-top: 1em;
+      padding-bottom: 1em;
       background-color: #0074D9;
       color: #fff;
       text-align: center;
@@ -188,49 +189,49 @@
   </div>
 
   <div class="container">
-    <div class="row collapse">
+    <div class="row">
       <div class="eleven columns offset-by-one">
         <div class="demo-col">eleven columns offset by one</div>
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="ten columns offset-by-two">
         <div class="demo-col">ten columns offset by two</div>
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="nine columns offset-by-three">
         <div class="demo-col">nine columns offset by three</div>
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="eight columns offset-by-four">
         <div class="demo-col">eight columns offset by four</div>
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="seven columns offset-by-five">
         <div class="demo-col">seven columns offset by five</div>
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="six columns offset-by-six">
         <div class="demo-col">six columns offset by six</div>
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="five columns offset-by-seven">
         <div class="demo-col">five columns offset by seven</div>
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="four columns">
         <div class="demo-col">four columns</div>
       </div>
@@ -239,13 +240,13 @@
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="three columns offset-by-nine">
         <div class="demo-col">three columns offset by nine</div>
       </div>
     </div>
 
-    <div class="row collapse">
+    <div class="row">
       <div class="six columns offset-by-three">
         <div class="demo-col">six columns offset by three</div>
       </div>
@@ -261,7 +262,7 @@
   </div>
   <br>
   <div class="container">
-    <div class="row collapse">
+    <div class="row">
       <div class="six columns">
         <div class="demo-col">six columns</div>
       </div>
@@ -269,7 +270,7 @@
         <div class="demo-col">
           six columns with nested grid
           <div class="container container__nested">
-            <div class="row collapse">
+            <div class="row">
               <div class="six columns">
                 <div class="demo-col nested">
                   six columns nested
@@ -281,7 +282,7 @@
                 </div>
               </div>
             </div>
-            <div class="row collapse">
+            <div class="row">
               <div class="twelve columns">
                 <div class="demo-col nested">
                   twelve columns nested
@@ -290,6 +291,49 @@
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+  <br>
+  <div class="container">
+    <div class="row">
+      <div class="tweleve columns">
+        <h3>responsive grids</h3>
+      </div>
+    </div>
+  </div>
+  <br>
+  <div class="container">
+    <div class="row">
+      <div class="xs-six sm-seven columns">
+        <div class="demo-col">xs-six sm-seven columns</div>
+      </div>
+      <div class="xs-six sm-five columns">
+        <div class="demo-col">xs-six sm-five columns</div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="sm-twelve md-six lg-four columns">
+        <div class="demo-col">sm-twelve md-six lg-four columns</div>
+      </div>
+      <div class="sm-twelve md-six lg-four columns">
+        <div class="demo-col">sm-twelve md-six lg-four columns</div>
+      </div>
+      <div class="sm-twelve lg-four columns">
+        <div class="demo-col">sm-twelve lg-four columns</div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="md-six columns">
+        <div class="demo-col">md-six columns</div>
+      </div>
+      <div class="md-six columns">
+        <div class="demo-col">md-six columns</div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="md-eight lg-six lg-offset-by-six columns">
+        <div class="demo-col">md-eight lg-six lg-offset-by-six columns</div>
       </div>
     </div>
   </div>

--- a/src/skeleton/_grid.css
+++ b/src/skeleton/_grid.css
@@ -55,6 +55,10 @@
 .xs-eleven[class*='column']       { width: calc((var(--column-width) * 11) - var(--gutter)); }
 .xs-twelve[class*='column']       { width: calc((var(--column-width) * 12) - var(--gutter)); }
 
+[class*='xs-'][class*='column'] ~ [class*='xs-'][class*='column'] {
+  margin-top: 0;
+}
+
 @media screen and (min-width: 35em) {
   [class*='column'] ~ [class*='column'] {
     margin-top: 0;

--- a/src/skeleton/_grid.css
+++ b/src/skeleton/_grid.css
@@ -1,100 +1,199 @@
+:root {
+  --total-columns: 12;
+  --column-width: calc(100%/var(--total-columns));
+  --max-width: 1240px;
+  --gutter: 1em;
+}
+
 .container {
   margin: 0 auto;
-  width: 94%;
-  max-width: 1240px;
+  width: calc(100% - var(--gutter));
+  max-width: var(--max-width);
+}
+
+.container .container {
+  margin-top: calc(var(--gutter) / 2);
+  width: calc(100% - (var(--gutter)  * 2));
 }
 
 .row {
-  margin-left: -0.5em;
-  margin-right: -0.5em;
+  margin-left: calc(-1 * (var(--gutter) / 2));
+  margin-right: calc(-1 * (var(--gutter) / 2));
 }
 
 .row::before,
-.row::after { content: " "; display: table; }
+.row::after { content: ' '; display: table; }
 .row::after { clear: both; }
 
-.column,
-.columns {
-  float: left;
-  width: calc(100% - 1em);
-  min-height: 1px;
-  margin-left: 0.5em;
-  margin-right: 0.5em;
+.row ~ .row,
+[class*='column'] ~ [class*='column'] {
+  margin-top: var(--gutter);
 }
 
-.row ~ .row,
-.column ~ .column,
-.columns ~ .column,
-.column ~ .columns,
-.columns ~ .columns { margin-top: 1em; }
+[class*='column'] {
+  width: calc(100% - var(--gutter));
+  float: left;
+  min-height: 1px;
+  margin-left: calc(var(--gutter) / 2);
+  margin-right: calc(var(--gutter) / 2);
+}
 
-@media (min-width: 35em) {
-  .column ~ .column,
-  .columns ~ .column,
-  .column ~ .columns,
-  .columns ~ .columns { margin-top: 0; }
+.xs-one[class*='column']          { width: calc((var(--column-width) * 1) - var(--gutter)); }
+.xs-two[class*='column']          { width: calc((var(--column-width) * 2) - var(--gutter)); }
+.xs-three[class*='column'],
+.xs-one-quarter[class*='column']  { width: calc((var(--column-width) * 3) - var(--gutter)); }
+.xs-four[class*='column'],
+.xs-one-third[class*='column']    { width: calc((var(--column-width) * 4) - var(--gutter)); }
+.xs-five[class*='column']         { width: calc((var(--column-width) * 5) - var(--gutter)); }
+.xs-six[class*='column'],
+.xs-one-half[class*='column']     { width: calc((var(--column-width) * 6) - var(--gutter)); }
+.xs-seven[class*='column']        { width: calc((var(--column-width) * 7) - var(--gutter)); }
+.xs-eight[class*='column'],
+.xs-two-thirds[class*='column']   { width: calc((var(--column-width) * 8) - var(--gutter)); }
+.xs-nine[class*='column']         { width: calc((var(--column-width) * 9) - var(--gutter)); }
+.xs-ten[class*='column']          { width: calc((var(--column-width) * 10) - var(--gutter)); }
+.xs-eleven[class*='column']       { width: calc((var(--column-width) * 11) - var(--gutter)); }
+.xs-twelve[class*='column']       { width: calc((var(--column-width) * 12) - var(--gutter)); }
 
-  .one.column,
-  .one.columns          { width: calc(((100%/12) * 1) - 1em); }
-  .two.column,
-  .two.columns          { width: calc(((100% / 12) * 2) - 1em); }
-  .three.column,
-  .three.columns,
-  .one-quarter.column,
-  .one-quarter.columns  { width: calc(((100% / 12) * 3) - 1em); }
-  .four.column,
-  .four.columns,
-  .one-third.column,
-  .one-third.columns    { width: calc(((100% / 12) * 4) - 1em); }
-  .five.column,
-  .five.columns         { width: calc(((100% / 12) * 5) - 1em); }
-  .six.column,
-  .six.columns,
-  .one-half.column,
-  .one-half.columns     { width: calc(((100% / 12) * 6) - 1em); }
-  .seven.column,
-  .seven.columns        { width: calc(((100% / 12) * 7) - 1em); }
-  .eight.column,
-  .eight.columns,
-  .two-thirds.column,
-  .two-thirds.columns   { width: calc(((100% / 12) * 8) - 1em); }
-  .nine.column,
-  .nine.columns         { width: calc(((100% / 12) * 9) - 1em); }
-  .ten.column,
-  .ten.columns          { width: calc(((100% / 12) * 10) - 1em); }
-  .eleven.column,
-  .eleven.columns       { width: calc(((100% / 12) * 11) - 1em); }
-  .twelve.column,
-  .twelve.columns       { width: calc(((100% / 12) * 12) - 1em); }
+@media screen and (min-width: 35em) {
+  [class*='column'] ~ [class*='column'] {
+    margin-top: 0;
+  }
 
-  .offset-by-one.column,
-  .offset-by-one.columns          { margin-left: calc(((100% / 12) * 1) + 0.5em); }
-  .offset-by-two.column,
-  .offset-by-two.columns          { margin-left: calc(((100% / 12) * 2) + 0.5em); }
-  .offset-by-three.column,
-  .offset-by-three.columns,
-  .offset-by-one-quarter.column,
-  .offset-by-one-quarter.columns  { margin-left: calc(((100% / 12) * 3) + 0.5em); }
-  .offset-by-four.column,
-  .offset-by-four.columns,
-  .offset-by-one-third.column,
-  .offset-by-one-third.columns    { margin-left: calc(((100% / 12) * 4) + 0.5em); }
-  .offset-by-five.column,
-  .offset-by-five.columns         { margin-left: calc(((100% / 12) * 5) + 0.5em); }
-  .offset-by-six.column,
-  .offset-by-six.columns,
-  .offset-by-one-half.column,
-  .offset-by-one-half.columns     { margin-left: calc(((100% / 12) * 6) + 0.5em); }
-  .offset-by-seven.column,
-  .offset-by-seven.columns        { margin-left: calc(((100% / 12) * 7) + 0.5em); }
-  .offset-by-eight.column,
-  .offset-by-eight.columns,
-  .offset-two-thirds.column,
-  .offset-two-thirds.columns      { margin-left: calc(((100% / 12) * 8) + 0.5em); }
-  .offset-by-nine.column,
-  .offset-by-nine.columns         { margin-left: calc(((100% / 12) * 9) + 0.5em); }
-  .offset-by-ten.column,
-  .offset-by-ten.columns          { margin-left: calc(((100% / 12) * 10) + 0.5em); }
-  .offset-by-eleven.column,
-  .offset-by-eleven.columns       { margin-left: calc(((100% / 12) * 11) + 0.5em); }
+  .one[class*='column']         { width: calc((var(--column-width) * 1) - var(--gutter)); }
+  .two[class*='column']         { width: calc((var(--column-width) * 2) - var(--gutter)); }
+  .three[class*='column'],
+  .one-quarter[class*='column'] { width: calc((var(--column-width) * 3) - var(--gutter)); }
+  .four[class*='column'],
+  .one-third[class*='column']   { width: calc((var(--column-width) * 4) - var(--gutter)); }
+  .five[class*='column']        { width: calc((var(--column-width) * 5) - var(--gutter)); }
+  .six[class*='column'],
+  .one-half[class*='column']    { width: calc((var(--column-width) * 6) - var(--gutter)); }
+  .seven[class*='column']       { width: calc((var(--column-width) * 7) - var(--gutter)); }
+  .eight[class*='column'],
+  .two-thirds[class*='column']  { width: calc((var(--column-width) * 8) - var(--gutter)); }
+  .nine[class*='column']        { width: calc((var(--column-width) * 9) - var(--gutter)); }
+  .ten[class*='column']         { width: calc((var(--column-width) * 10) - var(--gutter)); }
+  .eleven[class*='column']      { width: calc((var(--column-width) * 11) - var(--gutter)); }
+  .twelve[class*='column']      { width: calc((var(--column-width) * 12) - var(--gutter)); }
+
+  .offset-by-one[class*='column']         { margin-left: calc((var(--column-width) * 1) + (var(--gutter) / 2)); }
+  .offset-by-two[class*='column']         { margin-left: calc((var(--column-width) * 2) + (var(--gutter) / 2)); }
+  .offset-by-three[class*='column'],
+  .offset-by-one-quarter[class*='column'] { margin-left: calc((var(--column-width) * 3) + (var(--gutter) / 2)); }
+  .offset-by-four[class*='column'],
+  .offset-by-one-third[class*='column']   { margin-left: calc((var(--column-width) * 4) + (var(--gutter) / 2)); }
+  .offset-by-five[class*='column']        { margin-left: calc((var(--column-width) * 5) + (var(--gutter) / 2)); }
+  .offset-by-six[class*='column'],
+  .offset-by-one-half[class*='column']    { margin-left: calc((var(--column-width) * 6) + (var(--gutter) / 2)); }
+  .offset-by-seven[class*='column']       { margin-left: calc((var(--column-width) * 7) + (var(--gutter) / 2)); }
+  .offset-by-eight[class*='column'],
+  .offset-by-two-thirds[class*='column']  { margin-left: calc((var(--column-width) * 8) + (var(--gutter) / 2)); }
+  .offset-by-nine[class*='column']        { margin-left: calc((var(--column-width) * 9) + (var(--gutter) / 2)); }
+  .offset-by-ten[class*='column']         { margin-left: calc((var(--column-width) * 10) + (var(--gutter) / 2)); }
+  .offset-by-eleven[class*='column']      { margin-left: calc((var(--column-width) * 11) + (var(--gutter) / 2)); }
+
+
+  .sm-one[class*='column']          { width: calc((var(--column-width) * 1) - var(--gutter)); }
+  .sm-two[class*='column']          { width: calc((var(--column-width) * 2) - var(--gutter)); }
+  .sm-three[class*='column'],
+  .sm-one-quarter[class*='column']  { width: calc((var(--column-width) * 3) - var(--gutter)); }
+  .sm-four[class*='column'],
+  .sm-one-third[class*='column']    { width: calc((var(--column-width) * 4) - var(--gutter)); }
+  .sm-five[class*='column']         { width: calc((var(--column-width) * 5) - var(--gutter)); }
+  .sm-six[class*='column'],
+  .sm-one-half[class*='column']     { width: calc((var(--column-width) * 6) - var(--gutter)); }
+  .sm-seven[class*='column']        { width: calc((var(--column-width) * 7) - var(--gutter)); }
+  .sm-eight[class*='column'],
+  .sm-two-thirds[class*='column']   { width: calc((var(--column-width) * 8) - var(--gutter)); }
+  .sm-nine[class*='column']         { width: calc((var(--column-width) * 9) - var(--gutter)); }
+  .sm-ten[class*='column']          { width: calc((var(--column-width) * 10) - var(--gutter)); }
+  .sm-eleven[class*='column']       { width: calc((var(--column-width) * 11) - var(--gutter)); }
+  .sm-twelve[class*='column']       { width: calc((var(--column-width) * 12) - var(--gutter)); }
+
+  .sm-offset-by-one[class*='column']          { margin-left: calc((var(--column-width) * 1) + (var(--gutter) / 2)); }
+  .sm-offset-by-two[class*='column']          { margin-left: calc((var(--column-width) * 2) + (var(--gutter) / 2)); }
+  .sm-offset-by-three[class*='column'],
+  .sm-offset-by-one-quarter[class*='column']  { margin-left: calc((var(--column-width) * 3) + (var(--gutter) / 2)); }
+  .sm-offset-by-four[class*='column'],
+  .sm-offset-by-one-third[class*='column']    { margin-left: calc((var(--column-width) * 4) + (var(--gutter) / 2)); }
+  .sm-offset-by-five[class*='column']         { margin-left: calc((var(--column-width) * 5) + (var(--gutter) / 2)); }
+  .sm-offset-by-six[class*='column'],
+  .sm-offset-by-one-half[class*='column']     { margin-left: calc((var(--column-width) * 6) + (var(--gutter) / 2)); }
+  .sm-offset-by-seven[class*='column']        { margin-left: calc((var(--column-width) * 7) + (var(--gutter) / 2)); }
+  .sm-offset-by-eight[class*='column'],
+  .sm-offset-by-two-thirds[class*='column']   { margin-left: calc((var(--column-width) * 8) + (var(--gutter) / 2)); }
+  .sm-offset-by-nine[class*='column']         { margin-left: calc((var(--column-width) * 9) + (var(--gutter) / 2)); }
+  .sm-offset-by-ten[class*='column']          { margin-left: calc((var(--column-width) * 10) + (var(--gutter) / 2)); }
+  .sm-offset-by-eleven[class*='column']       { margin-left: calc((var(--column-width) * 11) + (var(--gutter) / 2)); }
+}
+
+@media screen and (min-width: 45em) {
+  .md-one[class*='column']          { width: calc((var(--column-width) * 1) - var(--gutter)); }
+  .md-two[class*='column']          { width: calc((var(--column-width) * 2) - var(--gutter)); }
+  .md-three[class*='column'],
+  .md-one-quarter[class*='column']  { width: calc((var(--column-width) * 3) - var(--gutter)); }
+  .md-four[class*='column'],
+  .md-one-third[class*='column']    { width: calc((var(--column-width) * 4) - var(--gutter)); }
+  .md-five[class*='column']         { width: calc((var(--column-width) * 5) - var(--gutter)); }
+  .md-six[class*='column'],
+  .md-one-half[class*='column']     { width: calc((var(--column-width) * 6) - var(--gutter)); }
+  .md-seven[class*='column']        { width: calc((var(--column-width) * 7) - var(--gutter)); }
+  .md-eight[class*='column'],
+  .md-two-thirds[class*='column']   { width: calc((var(--column-width) * 8) - var(--gutter)); }
+  .md-nine[class*='column']         { width: calc((var(--column-width) * 9) - var(--gutter)); }
+  .md-ten[class*='column']          { width: calc((var(--column-width) * 10) - var(--gutter)); }
+  .md-eleven[class*='column']       { width: calc((var(--column-width) * 11) - var(--gutter)); }
+  .md-twelve[class*='column']       { width: calc((var(--column-width) * 12) - var(--gutter)); }
+
+  .md-offset-by-one[class*='column']          { margin-left: calc((var(--column-width) * 1) + (var(--gutter) / 2)); }
+  .md-offset-by-two[class*='column']          { margin-left: calc((var(--column-width) * 2) + (var(--gutter) / 2)); }
+  .md-offset-by-three[class*='column'],
+  .md-offset-by-one-quarter[class*='column']  { margin-left: calc((var(--column-width) * 3) + (var(--gutter) / 2)); }
+  .md-offset-by-four[class*='column'],
+  .md-offset-by-one-third[class*='column']    { margin-left: calc((var(--column-width) * 4) + (var(--gutter) / 2)); }
+  .md-offset-by-five[class*='column']         { margin-left: calc((var(--column-width) * 5) + (var(--gutter) / 2)); }
+  .md-offset-by-six[class*='column'],
+  .md-offset-by-one-half[class*='column']     { margin-left: calc((var(--column-width) * 6) + (var(--gutter) / 2)); }
+  .md-offset-by-seven[class*='column']        { margin-left: calc((var(--column-width) * 7) + (var(--gutter) / 2)); }
+  .md-offset-by-eight[class*='column'],
+  .md-offset-by-two-thirds[class*='column']   { margin-left: calc((var(--column-width) * 8) + (var(--gutter) / 2)); }
+  .md-offset-by-nine[class*='column']         { margin-left: calc((var(--column-width) * 9) + (var(--gutter) / 2)); }
+  .md-offset-by-ten[class*='column']          { margin-left: calc((var(--column-width) * 10) + (var(--gutter) / 2)); }
+  .md-offset-by-eleven[class*='column']       { margin-left: calc((var(--column-width) * 11) + (var(--gutter) / 2)); }
+}
+
+@media screen and (min-width: 60em) {
+  .lg-one[class*='column']          { width: calc((var(--column-width) * 1) - var(--gutter)); }
+  .lg-two[class*='column']          { width: calc((var(--column-width) * 2) - var(--gutter)); }
+  .lg-three[class*='column'],
+  .lg-one-quarter[class*='column']  { width: calc((var(--column-width) * 3) - var(--gutter)); }
+  .lg-four[class*='column'],
+  .lg-one-third[class*='column']    { width: calc((var(--column-width) * 4) - var(--gutter)); }
+  .lg-five[class*='column']         { width: calc((var(--column-width) * 5) - var(--gutter)); }
+  .lg-six[class*='column'],
+  .lg-one-half[class*='column']     { width: calc((var(--column-width) * 6) - var(--gutter)); }
+  .lg-seven[class*='column']        { width: calc((var(--column-width) * 7) - var(--gutter)); }
+  .lg-eight[class*='column'],
+  .lg-two-thirds[class*='column']   { width: calc((var(--column-width) * 8) - var(--gutter)); }
+  .lg-nine[class*='column']         { width: calc((var(--column-width) * 9) - var(--gutter)); }
+  .lg-ten[class*='column']          { width: calc((var(--column-width) * 10) - var(--gutter)); }
+  .lg-eleven[class*='column']       { width: calc((var(--column-width) * 11) - var(--gutter)); }
+  .lg-twelve[class*='column']       { width: calc((var(--column-width) * 12) - var(--gutter)); }
+
+  .lg-offset-by-one[class*='column']          { margin-left: calc((var(--column-width) * 1) + (var(--gutter) / 2)); }
+  .lg-offset-by-two[class*='column']          { margin-left: calc((var(--column-width) * 2) + (var(--gutter) / 2)); }
+  .lg-offset-by-three[class*='column'],
+  .lg-offset-by-one-quarter[class*='column']  { margin-left: calc((var(--column-width) * 3) + (var(--gutter) / 2)); }
+  .lg-offset-by-four[class*='column'],
+  .lg-offset-by-one-third[class*='column']    { margin-left: calc((var(--column-width) * 4) + (var(--gutter) / 2)); }
+  .lg-offset-by-five[class*='column']         { margin-left: calc((var(--column-width) * 5) + (var(--gutter) / 2)); }
+  .lg-offset-by-six[class*='column'],
+  .lg-offset-by-one-half[class*='column']     { margin-left: calc((var(--column-width) * 6) + (var(--gutter) / 2)); }
+  .lg-offset-by-seven[class*='column']        { margin-left: calc((var(--column-width) * 7) + (var(--gutter) / 2)); }
+  .lg-offset-by-eight[class*='column'],
+  .lg-offset-by-two-thirds[class*='column']   { margin-left: calc((var(--column-width) * 8) + (var(--gutter) / 2)); }
+  .lg-offset-by-nine[class*='column']         { margin-left: calc((var(--column-width) * 9) + (var(--gutter) / 2)); }
+  .lg-offset-by-ten[class*='column']          { margin-left: calc((var(--column-width) * 10) + (var(--gutter) / 2)); }
+  .lg-offset-by-eleven[class*='column']       { margin-left: calc((var(--column-width) * 11) + (var(--gutter) / 2)); }
 }


### PR DESCRIPTION
This is no longer written in Vanilla CSS I know, I chose to leverage some of the things that postcss gives us. If the majority thinks this should stay as Vanilla CSS I am happy to remove the postcss specific things and make this vanilla css again.  

I added responsive grid sizes xs, sm, md, and lg and have also changed the .columns, .column selector to [class*='column'] so either can be used and it makes the resulting css a lot DRYer.

the changes to the `gulpfile` are so that it watches **anything** inside the src folder